### PR TITLE
Feature/1 Spring REST Docs 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 src/main/generated
+src/main/resources/static/docs

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ java {
 }
 
 configurations {
+	asciidoctorExt
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
@@ -38,17 +39,55 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	runtimeOnly 'com.h2database:h2:1.4.200'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// Spring REST Docs
+	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 }
 
-tasks.named('test') {
+// Spring REST Docs Setting
+ext {
+	set('snippetsDir', file("build/generated-snippets"))
+}
+
+test {
 	outputs.dir snippetsDir
 	useJUnitPlatform()
 }
 
-tasks.named('asciidoctor') {
+asciidoctor.doFirst {
+	delete file('src/main/resources/static/docs')
+}
+
+asciidoctor {
+	forkOptions {
+		jvmArgs(
+				'--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED',
+				'--add-opens', 'java.base/java.io=ALL-UNNAMED'
+		)
+	}
+
 	inputs.dir snippetsDir
+	configurations 'asciidoctorExt'
 	dependsOn test
+}
+
+tasks.register('copyDocument', Copy) {
+	dependsOn asciidoctor
+	from file("build/docs/asciidoc")
+	into file("src/main/resources/static/docs")
+}
+
+bootJar {
+	dependsOn asciidoctor
+	from("${asciidoctor.outputDir}") {
+		into 'static/docs'
+	}
+}
+
+build {
+	dependsOn copyDocument
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,69 @@
+= Golden-Ticket API Guide
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toc-levels: 4
+:sect-links:
+:operation-curl-request-title: Example Request
+:operation-http-response-title: Example Response
+
+[[overview_http_verbs]]
+== HTTP Methods
+
+Golden-Ticket API adheres as closely as possible to standard HTTP and REST conventions in its use of HTTP verbs.
+
+|===
+| Verb | Usage
+
+| GET
+| Used to retrieve a resource
+
+| POST
+| Used to create a new resource
+
+| PUT
+| Used to replace a representation of the target resource with the request payload
+
+| PATCH
+| Used to update an existing resource, including partial updates
+
+| DELETE
+| Used to delete an existing resource
+|===
+
+[[overview_http_status_codes]]
+== HTTP Status Codes
+
+Golden-Ticket API adheres as closely as possible to standard HTTP and REST conventions in its use of HTTP status codes.
+
+|===
+| Status Code | Usage
+
+| 200 OK
+| The request completed successfully
+
+| 201 Created
+| A new resource has been created successfully. The resource's URI is available from the response's Location header.
+
+| 204 No Content
+| An update to an existing resource has been applied successfully
+
+| 400 Bad Request
+| The request was malformed. The response body will include an error providing further information
+
+| 401 Unauthorized
+| The request has not been applied because it lacks valid authentication credentials for the target resource.
+
+| 403 Forbidden
+| The server understood the request but refuses to authorize it.
+
+| 404 Not Found
+| The requested resource did not exist
+
+| 409 Conflict
+| The request could not be completed due to a conflict with the current state of the target resource. This code is used in situations where the user might be able to resolve the conflict and resubmit the request.
+
+| 500 Internal Server Error
+| An unexpected internal server error occurred
+|===

--- a/src/test/java/site/goldenticket/common/ApiDocumentation.java
+++ b/src/test/java/site/goldenticket/common/ApiDocumentation.java
@@ -1,0 +1,55 @@
+package site.goldenticket.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.restdocs.snippet.Attributes.Attribute;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.snippet.Attributes.key;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class ApiDocumentation {
+
+    private static final String BASE_URL = "localhost";
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    protected OperationRequestPreprocessor getDocumentRequest() {
+        return preprocessRequest(modifyUris().host(BASE_URL).removePort(), prettyPrint());
+    }
+
+    protected OperationResponsePreprocessor getDocumentResponse() {
+        return preprocessResponse(prettyPrint());
+    }
+
+    protected Attribute getTimeFormat() {
+        return key("format").value("hh:mm");
+    }
+
+    protected Attribute getDateFormat() {
+        return key("format").value("yyyy-MM-dd");
+    }
+
+    protected Attribute getPhoneFormat() {
+        return key("format").value("000-0000-0000");
+    }
+
+    protected Attribute getEmailFormat() {
+        return key("format").value("email@gmail.com");
+    }
+}


### PR DESCRIPTION
Spring REST Docs 설정

- build.gradle
  - snippets 생성을 위한 빌드 설정 추가
  - Gradle build 결과로 생성된 asciidoc 파일 index.html로 `src/main/resources/static/docs` 경로에 생성하여, Spring Application 실행 시 API 문서를 확인 할 수 있도록 설정
  - asciidoctor 실행 전, 이미 생성된 API 문서 html 파일은 삭제하도록 설정

- index.adoc
  - Http Method와 Http Status 에 대한 설명을 제공하는 기본 adoc 파일 생성

- ApiDocumentation.class
  - Spring REST Docs 생성을 위한 테스트 코드 설정 세팅