### PR TITLE
Feature/1 QueryDSL 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,11 +33,18 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	annotationProcessor 'org.projectlombok:lombok'
 	compileOnly 'org.projectlombok:lombok'
 
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	runtimeOnly 'com.h2database:h2:1.4.200'
-	annotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.springframework.security:spring-security-test'
@@ -51,4 +58,19 @@ tasks.named('test') {
 tasks.named('asciidoctor') {
 	inputs.dir snippetsDir
 	dependsOn test
+}
+
+// QueryDSL Build Option
+def querydslDir = layout.buildDirectory.dir("generated/querydsl")
+
+sourceSets {
+	main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile).configureEach {
+	options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+clean.doLast {
+	file(querydslDir).deleteDir()
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,19 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;MODE=MYSQL
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
 
+  h2:
+    console:
+      enabled: true
+
+  jpa:
+    database-platform: H2
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true


### PR DESCRIPTION
QueryDSL 설정

- build.gradle
  - QueryDSL 5.0 라이브러리 의존성 추가
  - `generated/querydsl` 경로에 Qtype이 생성되도록 설정

- application.yml
  - H2 Database 설정
  - JPA 자동 DDL과 SQL Logging 설정