### PR TITLE
Feature/1 CICD 설정

### DIFF
--- a/.github/workflows/dev_CD.yml
+++ b/.github/workflows/dev_CD.yml
@@ -1,0 +1,88 @@
+name: Deploy to Amazon ECS
+
+on:
+  push:
+    branches:
+      - develop
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
+      - 'README.md'
+      - '.gitignore'
+
+env:
+  AWS_REGION: ap-northeast-2
+  ECR_REPOSITORY: golden-ticket-dev-repository
+  ECS_CLUSTER: golden-ticket-dev-cluster
+  ECS_SERVICE: golden-ticket-dev-api-service
+  ECS_TASK_DEFINITION: golden-ticket-dev-task
+  CONTAINER_NAME: golden-ticket-dev-container
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 17
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: build gradle
+        run: ./gradlew clean build
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Download Task Definition Template
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition ${{ env.ECS_TASK_DEFINITION }} \
+            --query taskDefinition \
+            > task-definition.json
+
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name: ${{ env.CONTAINER_NAME }}
+          image: ${{ steps.build-image.outputs.image }}
+
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: ${{ env.ECS_SERVICE }}
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true

--- a/.github/workflows/dev_CI.yml
+++ b/.github/workflows/dev_CI.yml
@@ -1,0 +1,35 @@
+name: Java CI with Gradle
+
+on:
+  pull_request:
+    branches:
+      - develop
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
+      - 'README.md'
+      - '.gitignore'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: CI with Gradle
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 17
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew clean build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM openjdk:17-ea-11-jdk-slim
+ARG JAR_FILE=/build/libs/*.jar
+COPY ${JAR_FILE} /app.jar
+ENTRYPOINT [ \
+  "java", \
+  "-jar", \
+  "app.jar" \
+]

--- a/build.gradle
+++ b/build.gradle
@@ -115,3 +115,7 @@ bootJar {
 build {
     dependsOn copyDocument
 }
+
+jar {
+    enabled = false
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+    hibernate:
+      ddl-auto: none
+
+  redis:
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}


### PR DESCRIPTION
Github Actions를 사용한 CICD 설정

- gradle.build
  - 빌드 결과 plain 파일 생성 비활성화

- CI
  - develop 브랜치에 PR 하는 시점에 진행
  - Gradle build 하는 단순한 검증

- Dockerfile
  - docker를 활용하여 빌드된 jar 파일을 실행하기 위한 이미지 컨테이너 생성
  - docker 이미지의 용량을 줄이기 위해 프로젝트를 빌드하는 설정을 분리

```
현재 프로젝트 빌드하는 설정은 Github Actions에서 실행
- Github Actions 에서 빌드하도록 workflow에 설정 - 유지
- Docker 컨테이너 빌드 시, 프로젝트로 빌드하도록 Dockerfile에 설정 - 수정
어떤게 좋을까요? 의견 주시면 좋을 것 같습니다!
```

- CD
  - develop 브랜치에 PUSH 하는 시점에 진행
  - 플로우
    - Gradle build -> jar 파일 생성
    - Docker build -> Docker 이미지 생성
    - AWS ECR에 PUSH -> ECR에 이미지 저장
    - AWS ECS 테스크 정의
    - AWS ECS 테스크 배포