### PR TITLE
Spring Security 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
     // Testcontainers Core
     implementation 'org.testcontainers:testcontainers:1.19.3'
 
+    // Rest Assured
+    testImplementation 'io.rest-assured:rest-assured:5.3.2'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/src/main/java/site/goldenticket/common/response/ErrorCode.java
+++ b/src/main/java/site/goldenticket/common/response/ErrorCode.java
@@ -15,6 +15,11 @@ public enum ErrorCode {
     COMMON_INVALID_PARAMETER(BAD_REQUEST, "요청한 값이 올바르지 않습니다."),
     COMMON_RESOURCE_NOT_FOUND(BAD_REQUEST, "존재하지 않는 리소스입니다."),
     COMMON_ENTITY_NOT_FOUND(BAD_REQUEST, "존재하지 않는 엔티티입니다."),
+
+    // Auth
+    EMPTY_EMAIL(BAD_REQUEST, "이메일은 필수 값 입니다."),
+    EMPTY_PASSWORD(BAD_REQUEST, "비밀번호는 필수 값 입니다."),
+    LOGIN_FAIL(BAD_REQUEST, "이메일, 비밀번호를 확인해주세요."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/site/goldenticket/common/response/ErrorCode.java
+++ b/src/main/java/site/goldenticket/common/response/ErrorCode.java
@@ -19,6 +19,8 @@ public enum ErrorCode {
     // Auth
     EMPTY_EMAIL(BAD_REQUEST, "이메일은 필수 값 입니다."),
     EMPTY_PASSWORD(BAD_REQUEST, "비밀번호는 필수 값 입니다."),
+    EMPTY_SUCCESS_HANDLER(INTERNAL_SERVER_ERROR, "SuccessHandler 필수 값 입니다."),
+    EMPTY_FAILURE_HANDLER(INTERNAL_SERVER_ERROR, "FailureHandler 필수 값 입니다."),
     LOGIN_FAIL(BAD_REQUEST, "이메일, 비밀번호를 확인해주세요."),
     ;
 

--- a/src/main/java/site/goldenticket/common/security/SecurityConfiguration.java
+++ b/src/main/java/site/goldenticket/common/security/SecurityConfiguration.java
@@ -5,15 +5,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import site.goldenticket.common.security.authentication.AuthenticationConfigurer;
 import site.goldenticket.common.security.authentication.SecurityAuthenticationFilter;
+import site.goldenticket.common.security.authentication.SecurityAuthenticationSuccessHandler;
 
 import static org.springframework.http.HttpMethod.GET;
 
@@ -41,10 +43,19 @@ public class SecurityConfiguration {
                         .requestMatchers(PathRequest.toH2Console()).permitAll()
                         .anyRequest().authenticated()
                 ).with(
-                        new AuthenticationConfigurer<>(new SecurityAuthenticationFilter(objectMapper)),
-                        Customizer.withDefaults()
+                        new AuthenticationConfigurer<>(createAuthenticationFilter()),
+                        SecurityAuthenticationFilter -> SecurityAuthenticationFilter
+                                .successHandler(createAuthenticationSuccessHandler())
                 );
 
         return http.getOrBuild();
+    }
+
+    private AbstractAuthenticationProcessingFilter createAuthenticationFilter() {
+        return new SecurityAuthenticationFilter(objectMapper);
+    }
+
+    private AuthenticationSuccessHandler createAuthenticationSuccessHandler() {
+        return new SecurityAuthenticationSuccessHandler(objectMapper);
     }
 }

--- a/src/main/java/site/goldenticket/common/security/SecurityConfiguration.java
+++ b/src/main/java/site/goldenticket/common/security/SecurityConfiguration.java
@@ -10,6 +10,8 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
@@ -32,6 +34,11 @@ public class SecurityConfiguration {
     };
 
     private final ObjectMapper objectMapper;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/site/goldenticket/common/security/SecurityConfiguration.java
+++ b/src/main/java/site/goldenticket/common/security/SecurityConfiguration.java
@@ -1,25 +1,33 @@
 package site.goldenticket.common.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import site.goldenticket.common.security.authentication.AuthenticationConfigurer;
+import site.goldenticket.common.security.authentication.SecurityAuthenticationFilter;
 
 import static org.springframework.http.HttpMethod.GET;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfiguration {
 
     private static final String[] PERMIT_ALL_GET_URLS = new String[]{
             "/favicon.ico",
             "/docs/**"
     };
+
+    private final ObjectMapper objectMapper;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -32,6 +40,9 @@ public class SecurityConfiguration {
                         .requestMatchers(GET, PERMIT_ALL_GET_URLS).permitAll()
                         .requestMatchers(PathRequest.toH2Console()).permitAll()
                         .anyRequest().authenticated()
+                ).with(
+                        new AuthenticationConfigurer<>(new SecurityAuthenticationFilter(objectMapper)),
+                        Customizer.withDefaults()
                 );
 
         return http.getOrBuild();

--- a/src/main/java/site/goldenticket/common/security/SecurityConfiguration.java
+++ b/src/main/java/site/goldenticket/common/security/SecurityConfiguration.java
@@ -12,8 +12,10 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import site.goldenticket.common.security.authentication.AuthenticationConfigurer;
+import site.goldenticket.common.security.authentication.SecurityAuthenticationFailureHandler;
 import site.goldenticket.common.security.authentication.SecurityAuthenticationFilter;
 import site.goldenticket.common.security.authentication.SecurityAuthenticationSuccessHandler;
 
@@ -46,6 +48,7 @@ public class SecurityConfiguration {
                         new AuthenticationConfigurer<>(createAuthenticationFilter()),
                         SecurityAuthenticationFilter -> SecurityAuthenticationFilter
                                 .successHandler(createAuthenticationSuccessHandler())
+                                .failureHandler(createAuthenticationFailureHandler())
                 );
 
         return http.getOrBuild();
@@ -57,5 +60,9 @@ public class SecurityConfiguration {
 
     private AuthenticationSuccessHandler createAuthenticationSuccessHandler() {
         return new SecurityAuthenticationSuccessHandler(objectMapper);
+    }
+
+    private AuthenticationFailureHandler createAuthenticationFailureHandler() {
+        return new SecurityAuthenticationFailureHandler(objectMapper);
     }
 }

--- a/src/main/java/site/goldenticket/common/security/authentication/AuthenticationConfigurer.java
+++ b/src/main/java/site/goldenticket/common/security/authentication/AuthenticationConfigurer.java
@@ -1,0 +1,64 @@
+package site.goldenticket.common.security.authentication;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import static site.goldenticket.common.response.ErrorCode.EMPTY_FAILURE_HANDLER;
+import static site.goldenticket.common.response.ErrorCode.EMPTY_SUCCESS_HANDLER;
+
+@RequiredArgsConstructor
+public class AuthenticationConfigurer<T extends AbstractAuthenticationProcessingFilter>
+        extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+    private final T authenticationFilter;
+
+    private AuthenticationSuccessHandler successHandler;
+    private AuthenticationFailureHandler failureHandler;
+
+    @Override
+    public void init(HttpSecurity builder) {
+    }
+
+    @Override
+    public void configure(HttpSecurity builder) {
+        validateHandler();
+        setAuthenticationFilter(builder);
+        builder.addFilterBefore(
+                authenticationFilter,
+                UsernamePasswordAuthenticationFilter.class
+        );
+    }
+
+    public AuthenticationConfigurer<T> successHandler(AuthenticationSuccessHandler successHandler) {
+        this.successHandler = successHandler;
+        return this;
+    }
+
+    public AuthenticationConfigurer<T> failureHandler(AuthenticationFailureHandler failureHandler) {
+        this.failureHandler = failureHandler;
+        return this;
+    }
+
+    private void validateHandler() {
+        if (successHandler == null) {
+            throw new IllegalStateException(EMPTY_SUCCESS_HANDLER.getMessage());
+        }
+
+        if (failureHandler == null) {
+            throw new IllegalStateException(EMPTY_FAILURE_HANDLER.getMessage());
+        }
+    }
+
+    private void setAuthenticationFilter(HttpSecurity builder) {
+        authenticationFilter.setAuthenticationManager(builder.getSharedObject(AuthenticationManager.class));
+        authenticationFilter.setAuthenticationSuccessHandler(successHandler);
+        authenticationFilter.setAuthenticationFailureHandler(failureHandler);
+    }
+}

--- a/src/main/java/site/goldenticket/common/security/authentication/SecurityAuthenticationFailureHandler.java
+++ b/src/main/java/site/goldenticket/common/security/authentication/SecurityAuthenticationFailureHandler.java
@@ -1,0 +1,53 @@
+package site.goldenticket.common.security.authentication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import site.goldenticket.common.response.CommonResponse;
+import site.goldenticket.common.security.exception.InvalidAuthenticationArgumentException;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static site.goldenticket.common.response.ErrorCode.LOGIN_FAIL;
+
+@Slf4j
+@RequiredArgsConstructor
+public class SecurityAuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationFailure(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException exception
+    ) throws IOException {
+        HttpStatus httpStatus;
+        CommonResponse<Void> commonResponse;
+
+        if (exception instanceof InvalidAuthenticationArgumentException) {
+            httpStatus = HttpStatus.BAD_REQUEST;
+            commonResponse = CommonResponse.fail(exception.getMessage());
+        } else {
+            httpStatus = HttpStatus.UNAUTHORIZED;
+            if (exception instanceof BadCredentialsException) {
+                commonResponse = CommonResponse.fail(LOGIN_FAIL.getMessage());
+            } else {
+                commonResponse = CommonResponse.fail(exception.getMessage());
+            }
+        }
+
+        response.setStatus(httpStatus.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        objectMapper.writeValue(response.getWriter(), commonResponse);
+    }
+}

--- a/src/main/java/site/goldenticket/common/security/authentication/SecurityAuthenticationFilter.java
+++ b/src/main/java/site/goldenticket/common/security/authentication/SecurityAuthenticationFilter.java
@@ -1,0 +1,55 @@
+package site.goldenticket.common.security.authentication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import site.goldenticket.common.security.authentication.dto.LoginRequest;
+import site.goldenticket.common.security.exception.InvalidAuthenticationArgumentException;
+
+import java.io.IOException;
+
+import static site.goldenticket.common.response.ErrorCode.COMMON_INVALID_PARAMETER;
+
+@Slf4j
+public class SecurityAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+
+    private static final AntPathRequestMatcher DEFAULT_ANT_PATH_REQUEST_MATCHER =
+            new AntPathRequestMatcher("/login", "POST");
+
+    private final ObjectMapper objectMapper;
+
+    public SecurityAuthenticationFilter(ObjectMapper objectMapper) {
+        super(DEFAULT_ANT_PATH_REQUEST_MATCHER);
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Authentication attemptAuthentication(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) throws AuthenticationException {
+        LoginRequest loginRequest = getLoginInfo(request);
+        String email = loginRequest.email();
+        String password = loginRequest.password();
+        log.info("Login email = {} / password = {}", email, password);
+
+        UsernamePasswordAuthenticationToken authRequest =
+                UsernamePasswordAuthenticationToken.unauthenticated(email, password);
+        return getAuthenticationManager().authenticate(authRequest);
+    }
+
+    private LoginRequest getLoginInfo(HttpServletRequest request) {
+        try {
+            return objectMapper.readValue(request.getReader(), LoginRequest.class);
+        } catch (IOException e) {
+            log.error(e.getMessage());
+            throw new InvalidAuthenticationArgumentException(COMMON_INVALID_PARAMETER);
+        }
+    }
+}

--- a/src/main/java/site/goldenticket/common/security/authentication/SecurityAuthenticationSuccessHandler.java
+++ b/src/main/java/site/goldenticket/common/security/authentication/SecurityAuthenticationSuccessHandler.java
@@ -1,0 +1,38 @@
+package site.goldenticket.common.security.authentication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class SecurityAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) throws IOException {
+        String email = authentication.getName();
+        log.info("Authentication Name = {}", email);
+
+        // TODO: 토큰 발급
+        String token = "token";
+
+        response.setStatus(HttpStatus.OK.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), token);
+    }
+}

--- a/src/main/java/site/goldenticket/common/security/authentication/dto/LoginRequest.java
+++ b/src/main/java/site/goldenticket/common/security/authentication/dto/LoginRequest.java
@@ -1,0 +1,20 @@
+package site.goldenticket.common.security.authentication.dto;
+
+import org.springframework.util.StringUtils;
+import site.goldenticket.common.security.exception.InvalidAuthenticationArgumentException;
+
+import static site.goldenticket.common.response.ErrorCode.EMPTY_EMAIL;
+import static site.goldenticket.common.response.ErrorCode.EMPTY_PASSWORD;
+
+public record LoginRequest(String email, String password) {
+
+    public LoginRequest {
+        if (!StringUtils.hasText(email)) {
+            throw new InvalidAuthenticationArgumentException(EMPTY_EMAIL);
+        }
+
+        if (!StringUtils.hasText(password)) {
+            throw new InvalidAuthenticationArgumentException(EMPTY_PASSWORD);
+        }
+    }
+}

--- a/src/main/java/site/goldenticket/common/security/exception/InvalidAuthenticationArgumentException.java
+++ b/src/main/java/site/goldenticket/common/security/exception/InvalidAuthenticationArgumentException.java
@@ -1,0 +1,11 @@
+package site.goldenticket.common.security.exception;
+
+import org.springframework.security.core.AuthenticationException;
+import site.goldenticket.common.response.ErrorCode;
+
+public class InvalidAuthenticationArgumentException extends AuthenticationException {
+
+    public InvalidAuthenticationArgumentException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+    }
+}

--- a/src/main/java/site/goldenticket/domain/security/PrincipalDetails.java
+++ b/src/main/java/site/goldenticket/domain/security/PrincipalDetails.java
@@ -1,0 +1,46 @@
+package site.goldenticket.domain.security;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.UserDetails;
+import site.goldenticket.domain.user.entity.User;
+
+import java.util.Collection;
+
+public record PrincipalDetails(User user) implements UserDetails {
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return AuthorityUtils.createAuthorityList(user.getRole().name());
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/site/goldenticket/domain/security/service/SecurityService.java
+++ b/src/main/java/site/goldenticket/domain/security/service/SecurityService.java
@@ -1,0 +1,30 @@
+package site.goldenticket.domain.security.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import site.goldenticket.domain.security.PrincipalDetails;
+import site.goldenticket.domain.user.entity.User;
+import site.goldenticket.domain.user.repository.UserRepository;
+
+import static site.goldenticket.common.response.ErrorCode.LOGIN_FAIL;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SecurityService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException(LOGIN_FAIL.getMessage()));
+
+        log.info("LoadUser User = {}", user);
+        return new PrincipalDetails(user);
+    }
+}

--- a/src/main/java/site/goldenticket/domain/user/entity/RoleType.java
+++ b/src/main/java/site/goldenticket/domain/user/entity/RoleType.java
@@ -1,0 +1,5 @@
+package site.goldenticket.domain.user.entity;
+
+public enum RoleType {
+    ROLE_GUEST, ROLE_USER, ROLE_ADMIN
+}

--- a/src/main/java/site/goldenticket/domain/user/entity/User.java
+++ b/src/main/java/site/goldenticket/domain/user/entity/User.java
@@ -1,0 +1,61 @@
+package site.goldenticket.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "users")
+@SQLRestriction("deleted = false")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    private String name;
+    private String nickname;
+    private String email;
+    private String password;
+    private String phoneNumber;
+    private String imageUrl;
+    private String yanoljaId;
+
+    @Enumerated(STRING)
+    private RoleType role;
+
+    private String bankName;
+    private String accountNumber;
+    private boolean deleted;
+    private String withdrawalReason;
+    private String withdrawalAt;
+
+    @Builder
+    private User(
+            String name,
+            String nickname,
+            String email,
+            String password,
+            String phoneNumber,
+            String imageUrl,
+            String yanoljaId,
+            RoleType role
+    ) {
+        this.name = name;
+        this.nickname = nickname;
+        this.email = email;
+        this.password = password;
+        this.phoneNumber = phoneNumber;
+        this.imageUrl = imageUrl;
+        this.yanoljaId = yanoljaId;
+        this.role = role;
+    }
+}

--- a/src/main/java/site/goldenticket/domain/user/repository/UserRepository.java
+++ b/src/main/java/site/goldenticket/domain/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package site.goldenticket.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.goldenticket.domain.user.entity.User;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+}

--- a/src/test/java/site/goldenticket/common/ApiTest.java
+++ b/src/test/java/site/goldenticket/common/ApiTest.java
@@ -1,0 +1,20 @@
+package site.goldenticket.common;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@ExtendWith(DatabaseClearExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public abstract class ApiTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void init() {
+        RestAssured.port = port;
+    }
+}

--- a/src/test/java/site/goldenticket/common/DatabaseCleaner.java
+++ b/src/test/java/site/goldenticket/common/DatabaseCleaner.java
@@ -1,0 +1,52 @@
+package site.goldenticket.common;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Component
+public class DatabaseCleaner {
+
+    private final List<String> tableNames = new ArrayList<>();
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @PostConstruct
+    private void findDatabaseTableNames() {
+        Query showTables = entityManager.createNativeQuery("SHOW TABLES");
+        if (Objects.isNull(showTables)) {
+            return;
+        }
+
+        List<Object[]> tableInfos = showTables.getResultList();
+        for (Object[] tableInfo : tableInfos) {
+            String tableName = (String) tableInfo[0];
+            tableNames.add(tableName);
+        }
+    }
+
+    private void truncate() {
+        entityManager.createNativeQuery(String.format("SET FOREIGN_KEY_CHECKS %d", 0))
+            .executeUpdate();
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery(String.format("TRUNCATE TABLE %s", tableName))
+                .executeUpdate();
+        }
+        entityManager.createNativeQuery(String.format("SET FOREIGN_KEY_CHECKS %d", 1))
+            .executeUpdate();
+    }
+
+    @Transactional
+    public void clear() {
+        entityManager.clear();
+        truncate();
+    }
+}

--- a/src/test/java/site/goldenticket/common/DatabaseClearExtension.java
+++ b/src/test/java/site/goldenticket/common/DatabaseClearExtension.java
@@ -1,0 +1,20 @@
+package site.goldenticket.common;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class DatabaseClearExtension implements BeforeEachCallback {
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        DatabaseCleaner databaseCleaner = getDataCleaner(context);
+        databaseCleaner.clear();
+    }
+
+    private DatabaseCleaner getDataCleaner(ExtensionContext extensionContext) {
+        return SpringExtension
+                .getApplicationContext(extensionContext)
+                .getBean(DatabaseCleaner.class);
+    }
+}

--- a/src/test/java/site/goldenticket/common/SecurityTest.java
+++ b/src/test/java/site/goldenticket/common/SecurityTest.java
@@ -1,0 +1,141 @@
+package site.goldenticket.common;
+
+import io.restassured.RestAssured;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import site.goldenticket.domain.user.entity.User;
+import site.goldenticket.domain.user.repository.UserRepository;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static site.goldenticket.common.response.Status.FAIL;
+import static site.goldenticket.common.utils.UserUtils.*;
+
+@DisplayName("Security 검증")
+public class SecurityTest extends ApiTest {
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        User user = createUser(passwordEncoder.encode(PASSWORD));
+        userRepository.save(user);
+    }
+
+    @Test
+    @DisplayName("로그인 성공")
+    void login_Success() {
+        // given
+        Map<String, Object> param = Map.of(
+                "email", EMAIL,
+                "password", PASSWORD
+        );
+
+        // when
+        ExtractableResponse<Response> result = RestAssured
+                .given().log().all()
+                .contentType(APPLICATION_JSON_VALUE)
+                .body(param)
+                .when()
+                .post("/login")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(result.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 존재하지 않는 이메일")
+    void login_FailureNotFoundEmail() {
+        // given
+        Map<String, Object> param = Map.of(
+                "email", "EMAIL",
+                "password", PASSWORD
+        );
+
+        // when
+        ExtractableResponse<Response> result = RestAssured
+                .given().log().all()
+                .contentType(APPLICATION_JSON_VALUE)
+                .body(param)
+                .when()
+                .post("/login")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(result.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+
+        JsonPath jsonPath = result.jsonPath();
+        assertAll(
+                () -> assertThat(jsonPath.getString("status")).isEqualTo(FAIL.name()),
+                () -> assertThat(jsonPath.getString("message")).isEqualTo("이메일, 비밀번호를 확인해주세요.")
+        );
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 잘못된 패스워드")
+    void login_FailureMismatchPassword() {
+        // given
+        Map<String, Object> param = Map.of(
+                "email", EMAIL,
+                "password", "PASSWORD"
+        );
+
+        // when
+        ExtractableResponse<Response> result = RestAssured
+                .given().log().all()
+                .contentType(APPLICATION_JSON_VALUE)
+                .body(param)
+                .when()
+                .post("/login")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(result.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+
+        JsonPath jsonPath = result.jsonPath();
+        assertAll(
+                () -> assertThat(jsonPath.getString("status")).isEqualTo(FAIL.name()),
+                () -> assertThat(jsonPath.getString("message")).isEqualTo("이메일, 비밀번호를 확인해주세요.")
+        );
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 잘못된 요청")
+    void login_FailureInvalidRequest() {
+        // when
+        ExtractableResponse<Response> result = RestAssured
+                .given().log().all()
+                .contentType(APPLICATION_JSON_VALUE)
+                .when()
+                .post("/login")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(result.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+
+        JsonPath jsonPath = result.jsonPath();
+        assertAll(
+                () -> assertThat(jsonPath.getString("status")).isEqualTo(FAIL.name()),
+                () -> assertThat(jsonPath.getString("message")).isEqualTo("요청한 값이 올바르지 않습니다.")
+        );
+    }
+}

--- a/src/test/java/site/goldenticket/common/utils/UserUtils.java
+++ b/src/test/java/site/goldenticket/common/utils/UserUtils.java
@@ -1,0 +1,25 @@
+package site.goldenticket.common.utils;
+
+import site.goldenticket.domain.user.entity.User;
+
+import static site.goldenticket.domain.user.entity.RoleType.ROLE_USER;
+
+public final class UserUtils {
+
+    public static String EMAIL = "email@gamil.com";
+    public static String PASSWORD = "password";
+    public static String NAME = "name";
+    public static String NICKNAME = "nickname";
+    public static String PHONENUMBER = "010-0000-0000";
+
+    public static User createUser(String encodePassword) {
+        return User.builder()
+                .email(EMAIL)
+                .password(encodePassword)
+                .name(NAME)
+                .nickname(NICKNAME)
+                .phoneNumber(PHONENUMBER)
+                .role(ROLE_USER)
+                .build();
+    }
+}


### PR DESCRIPTION
Spring Security 인증입니다.

- 인증 필터 구현
- RequestBody를 사용하기 위해 `UsernamePasswordAuthenticationFilter`를 대신해 `AbstractAuthenticationProcessingFilter`를 확장해서 대신 사용
- 로그인 성공/실패 Handler 구현
  - to-be 로그인 성공에 따른 JWT를 반환할 예정입니다.

테스트 설정
- API 테스트를 위한 RestAssured 라이브러리를 추가
- 로그인에 대한 성공/실패 테스트
- to-be Spring REST Docs 작성 예정입니다.

코드량 조절에 실패했습니다...
더 나눠서 PR 올리고 싶었는데... 인증 관련 로직을 더 쪼개기가 어려워서 이번만 양해 부탁드립니다...🙇