### PR TITLE
Feature/56 알림 관련 API 구현

### DIFF
--- a/src/main/java/site/goldenticket/domain/alert/controller/AlertController.java
+++ b/src/main/java/site/goldenticket/domain/alert/controller/AlertController.java
@@ -1,12 +1,25 @@
 package site.goldenticket.domain.alert.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import site.goldenticket.common.response.CommonResponse;
+import site.goldenticket.domain.alert.dto.AlertListResponse;
+import site.goldenticket.domain.alert.service.AlertService;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/alerts")
 public class AlertController {
 
+    private final AlertService alertService;
+
+    @GetMapping
+    public ResponseEntity<CommonResponse<AlertListResponse>> getAlertList() {
+        Long userId = 1L; //시큐리티 적용 후 수정 예정
+        return ResponseEntity.ok(
+            CommonResponse.ok("알림 목록이 조회되었습니다.", alertService.getAlertListByUserId(userId)));
+    }
 }

--- a/src/main/java/site/goldenticket/domain/alert/controller/AlertController.java
+++ b/src/main/java/site/goldenticket/domain/alert/controller/AlertController.java
@@ -1,0 +1,12 @@
+package site.goldenticket.domain.alert.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/alerts")
+public class AlertController {
+
+}

--- a/src/main/java/site/goldenticket/domain/alert/controller/AlertController.java
+++ b/src/main/java/site/goldenticket/domain/alert/controller/AlertController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import site.goldenticket.common.response.CommonResponse;
 import site.goldenticket.domain.alert.dto.AlertListResponse;
+import site.goldenticket.domain.alert.dto.AlertUnSeenResponse;
 import site.goldenticket.domain.alert.service.AlertService;
 
 @RestController
@@ -16,10 +17,19 @@ public class AlertController {
 
     private final AlertService alertService;
 
+    @GetMapping("/unseen")
+    public ResponseEntity<CommonResponse<AlertUnSeenResponse>> getAlertUnSeen() {
+        Long userId = 1L; //시큐리티 적용 후 수정 예정
+        return ResponseEntity.ok(
+            CommonResponse.ok("안읽은 알림 존재 여부가 조회되었습니다.",
+                alertService.getExistsNewAlert(userId)));
+    }
+
     @GetMapping
     public ResponseEntity<CommonResponse<AlertListResponse>> getAlertList() {
         Long userId = 1L; //시큐리티 적용 후 수정 예정
         return ResponseEntity.ok(
-            CommonResponse.ok("알림 목록이 조회되었습니다.", alertService.getAlertListByUserId(userId)));
+            CommonResponse.ok("알림 목록이 조회되었습니다.",
+                alertService.getAlertListByUserId(userId)));
     }
 }

--- a/src/main/java/site/goldenticket/domain/alert/controller/AlertController.java
+++ b/src/main/java/site/goldenticket/domain/alert/controller/AlertController.java
@@ -2,6 +2,7 @@ package site.goldenticket.domain.alert.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,6 +10,7 @@ import site.goldenticket.common.response.CommonResponse;
 import site.goldenticket.domain.alert.dto.AlertListResponse;
 import site.goldenticket.domain.alert.dto.AlertUnSeenResponse;
 import site.goldenticket.domain.alert.service.AlertService;
+import site.goldenticket.domain.security.PrincipalDetails;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,18 +20,20 @@ public class AlertController {
     private final AlertService alertService;
 
     @GetMapping("/unseen")
-    public ResponseEntity<CommonResponse<AlertUnSeenResponse>> getAlertUnSeen() {
-        Long userId = 1L; //시큐리티 적용 후 수정 예정
+    public ResponseEntity<CommonResponse<AlertUnSeenResponse>> getAlertUnSeen(
+        @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
         return ResponseEntity.ok(
             CommonResponse.ok("안읽은 알림 존재 여부가 조회되었습니다.",
-                alertService.getExistsNewAlert(userId)));
+                alertService.getExistsNewAlert(principalDetails.getUserId())));
     }
 
     @GetMapping
-    public ResponseEntity<CommonResponse<AlertListResponse>> getAlertList() {
-        Long userId = 1L; //시큐리티 적용 후 수정 예정
+    public ResponseEntity<CommonResponse<AlertListResponse>> getAlertList(
+        @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
         return ResponseEntity.ok(
             CommonResponse.ok("알림 목록이 조회되었습니다.",
-                alertService.getAlertListByUserId(userId)));
+                alertService.getAlertListByUserId(principalDetails.getUserId())));
     }
 }

--- a/src/main/java/site/goldenticket/domain/alert/dto/AlertListResponse.java
+++ b/src/main/java/site/goldenticket/domain/alert/dto/AlertListResponse.java
@@ -1,0 +1,11 @@
+package site.goldenticket.domain.alert.dto;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record AlertListResponse(
+    List<AlertResponse> alertResponses
+) {
+
+}

--- a/src/main/java/site/goldenticket/domain/alert/dto/AlertResponse.java
+++ b/src/main/java/site/goldenticket/domain/alert/dto/AlertResponse.java
@@ -1,0 +1,14 @@
+package site.goldenticket.domain.alert.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record AlertResponse(
+    Long alertId,
+    String content,
+    Boolean viewed,
+    LocalDateTime createdAt
+) {
+
+}

--- a/src/main/java/site/goldenticket/domain/alert/dto/AlertUnSeenResponse.java
+++ b/src/main/java/site/goldenticket/domain/alert/dto/AlertUnSeenResponse.java
@@ -1,0 +1,10 @@
+package site.goldenticket.domain.alert.dto;
+
+import lombok.Builder;
+
+@Builder
+public record AlertUnSeenResponse(
+    Boolean existsNewAlert
+) {
+
+}

--- a/src/main/java/site/goldenticket/domain/alert/entity/Alert.java
+++ b/src/main/java/site/goldenticket/domain/alert/entity/Alert.java
@@ -1,0 +1,36 @@
+package site.goldenticket.domain.alert.entity;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.goldenticket.common.entiy.BaseTimeEntity;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class Alert extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private String content;
+
+    private Boolean viewed;
+
+    @Builder
+    public Alert(Long id, Long userId, String content, Boolean viewed) {
+        this.id = id;
+        this.userId = userId;
+        this.content = content;
+        this.viewed = viewed;
+    }
+}

--- a/src/main/java/site/goldenticket/domain/alert/entity/Alert.java
+++ b/src/main/java/site/goldenticket/domain/alert/entity/Alert.java
@@ -33,4 +33,8 @@ public class Alert extends BaseTimeEntity {
         this.content = content;
         this.viewed = viewed;
     }
+
+    public void updateAlertViewed() {
+        this.viewed = true;
+    }
 }

--- a/src/main/java/site/goldenticket/domain/alert/repository/AlertRepository.java
+++ b/src/main/java/site/goldenticket/domain/alert/repository/AlertRepository.java
@@ -1,0 +1,8 @@
+package site.goldenticket.domain.alert.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.goldenticket.domain.alert.entity.Alert;
+
+public interface AlertRepository extends JpaRepository<Alert, Long> {
+
+}

--- a/src/main/java/site/goldenticket/domain/alert/repository/AlertRepository.java
+++ b/src/main/java/site/goldenticket/domain/alert/repository/AlertRepository.java
@@ -6,5 +6,6 @@ import site.goldenticket.domain.alert.entity.Alert;
 
 public interface AlertRepository extends JpaRepository<Alert, Long> {
 
+    Boolean existsByUserIdAndViewed(Long userId, Boolean viewed);
     List<Alert> findAllByUserId(Long userId);
 }

--- a/src/main/java/site/goldenticket/domain/alert/repository/AlertRepository.java
+++ b/src/main/java/site/goldenticket/domain/alert/repository/AlertRepository.java
@@ -1,8 +1,10 @@
 package site.goldenticket.domain.alert.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.goldenticket.domain.alert.entity.Alert;
 
 public interface AlertRepository extends JpaRepository<Alert, Long> {
 
+    List<Alert> findAllByUserId(Long userId);
 }

--- a/src/main/java/site/goldenticket/domain/alert/service/AlertService.java
+++ b/src/main/java/site/goldenticket/domain/alert/service/AlertService.java
@@ -1,0 +1,12 @@
+package site.goldenticket.domain.alert.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AlertService {
+
+}

--- a/src/main/java/site/goldenticket/domain/alert/service/AlertService.java
+++ b/src/main/java/site/goldenticket/domain/alert/service/AlertService.java
@@ -1,12 +1,34 @@
 package site.goldenticket.domain.alert.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import site.goldenticket.domain.alert.dto.AlertListResponse;
+import site.goldenticket.domain.alert.dto.AlertResponse;
+import site.goldenticket.domain.alert.entity.Alert;
+import site.goldenticket.domain.alert.repository.AlertRepository;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class AlertService {
 
+    private final AlertRepository alertRepository;
+
+    public AlertListResponse getAlertListByUserId(Long userId) {
+        List<Alert> alerts = alertRepository.findAllByUserId(userId);
+        List<AlertResponse> alertResponses = new ArrayList<>();
+        for (Alert alert : alerts) {
+            alertResponses.add(
+                AlertResponse.builder()
+                    .alertId(alert.getId())
+                    .content(alert.getContent())
+                    .createdAt(alert.getCreatedAt())
+                    .build()
+            );
+        }
+        return AlertListResponse.builder().alertResponses(alertResponses).build();
+    }
 }

--- a/src/main/java/site/goldenticket/domain/alert/service/AlertService.java
+++ b/src/main/java/site/goldenticket/domain/alert/service/AlertService.java
@@ -35,6 +35,10 @@ public class AlertService {
                     .createdAt(alert.getCreatedAt())
                     .build()
             );
+            if (!alert.getViewed()) {
+                alert.updateAlertViewed();
+                alertRepository.save(alert);
+            }
         }
         return AlertListResponse.builder().alertResponses(alertResponses).build();
     }

--- a/src/main/java/site/goldenticket/domain/alert/service/AlertService.java
+++ b/src/main/java/site/goldenticket/domain/alert/service/AlertService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.goldenticket.domain.alert.dto.AlertListResponse;
 import site.goldenticket.domain.alert.dto.AlertResponse;
+import site.goldenticket.domain.alert.dto.AlertUnSeenResponse;
 import site.goldenticket.domain.alert.entity.Alert;
 import site.goldenticket.domain.alert.repository.AlertRepository;
 
@@ -16,6 +17,12 @@ import site.goldenticket.domain.alert.repository.AlertRepository;
 public class AlertService {
 
     private final AlertRepository alertRepository;
+
+    public AlertUnSeenResponse getExistsNewAlert(Long userId) {
+        return AlertUnSeenResponse.builder()
+            .existsNewAlert(alertRepository.existsByUserIdAndViewed(userId, false))
+            .build();
+    }
 
     public AlertListResponse getAlertListByUserId(Long userId) {
         List<Alert> alerts = alertRepository.findAllByUserId(userId);

--- a/src/main/java/site/goldenticket/domain/alert/service/AlertService.java
+++ b/src/main/java/site/goldenticket/domain/alert/service/AlertService.java
@@ -1,6 +1,8 @@
 package site.goldenticket.domain.alert.service;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -41,6 +43,9 @@ public class AlertService {
                 alertRepository.save(alert);
             }
         }
+
+        Collections.sort(alertResponses,
+            Comparator.comparing(AlertResponse::createdAt).reversed());
         return AlertListResponse.builder().alertResponses(alertResponses).build();
     }
 }

--- a/src/main/java/site/goldenticket/domain/alert/service/AlertService.java
+++ b/src/main/java/site/goldenticket/domain/alert/service/AlertService.java
@@ -32,6 +32,7 @@ public class AlertService {
                 AlertResponse.builder()
                     .alertId(alert.getId())
                     .content(alert.getContent())
+                    .viewed(alert.getViewed())
                     .createdAt(alert.getCreatedAt())
                     .build()
             );


### PR DESCRIPTION
**개발내용**
-
- 알림 패키지 설계 
- 알림 목록 조회 API 구현 
- 안읽은 알림 유무 조회 API 구현
- 알림 목록 조회 시, 조회 여부값 추가 & 조회 후 읽음처리(viewed=true) 
- 로컬 테스트 완료
![image](https://github.com/Yanol-Market/backend/assets/76683396/8cd9a053-8549-4818-8de4-e149fc0041dc)


**추가 사항**
-
- [ ] 경로 권한 설정
- [ ] controller에 시큐리티 적용

**전달 사항**
- git 명령어 실수로 바로 develop으로 merge하는 PR을 올렸습니다ㅠㅠ
