### PR TITLE
Feature/58 chat room detail 채팅방 상세 조회 

### DIFF
--- a/src/main/java/site/goldenticket/common/response/ErrorCode.java
+++ b/src/main/java/site/goldenticket/common/response/ErrorCode.java
@@ -34,6 +34,13 @@ public enum ErrorCode {
     // User
     ALREADY_EXIST_EMAIL(BAD_REQUEST, "이미 사용중인 이메일입니다. 이미 가입하신 적이 있다면 로그인을 시도해주세요"),
     ALREADY_EXIST_NICKNAME(BAD_REQUEST, "이미 사용중인 아이디입니다."),
+    USER_NOT_FOUND(BAD_REQUEST, "존재하지 않는 회원입니다."),
+
+    //Product
+    PRODUCT_NOT_FOUND(NOT_FOUND, "존재하지 않는 양도 상품입니다."),
+
+    //Chat
+    CHAT_ROOM_NOT_FOUND(NOT_FOUND, "존재하지 않는 채팅방입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/site/goldenticket/domain/chat/controller/ChatController.java
+++ b/src/main/java/site/goldenticket/domain/chat/controller/ChatController.java
@@ -1,12 +1,28 @@
 package site.goldenticket.domain.chat.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import site.goldenticket.common.response.CommonResponse;
+import site.goldenticket.domain.chat.dto.ChatRoomDetailResponse;
+import site.goldenticket.domain.chat.service.ChatService;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/chats")
 public class ChatController {
+
+    private final ChatService chatService;
+
+    @GetMapping("/{chatRoomId}")
+    public ResponseEntity<CommonResponse<ChatRoomDetailResponse>> getChatRoom(
+        @PathVariable Long chatRoomId) {
+        Long userId = 1L; //시큐리티 적용 후 수정 예정
+        return ResponseEntity.ok(CommonResponse.ok("채팅방 상세 정보를 조회했습니다",
+            chatService.getChatRoomDetail(userId, chatRoomId)));
+    }
 
 }

--- a/src/main/java/site/goldenticket/domain/chat/dto/ChatResponse.java
+++ b/src/main/java/site/goldenticket/domain/chat/dto/ChatResponse.java
@@ -1,0 +1,16 @@
+package site.goldenticket.domain.chat.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import site.goldenticket.domain.chat.entity.SenderType;
+
+@Builder
+public record ChatResponse(
+    Long chatId,
+    SenderType senderType,
+    Long userId,
+    String content,
+    LocalDateTime createdAt
+) {
+
+}

--- a/src/main/java/site/goldenticket/domain/chat/dto/ChatRoomDetailResponse.java
+++ b/src/main/java/site/goldenticket/domain/chat/dto/ChatRoomDetailResponse.java
@@ -1,0 +1,12 @@
+package site.goldenticket.domain.chat.dto;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record ChatRoomDetailResponse(
+    ChatRoomInfoResponse chatRoomInfoResponse,
+    List<ChatResponse> chatResponseList
+) {
+
+}

--- a/src/main/java/site/goldenticket/domain/chat/dto/ChatRoomInfoResponse.java
+++ b/src/main/java/site/goldenticket/domain/chat/dto/ChatRoomInfoResponse.java
@@ -1,0 +1,18 @@
+package site.goldenticket.domain.chat.dto;
+
+import lombok.Builder;
+import site.goldenticket.common.constants.ProductStatus;
+
+@Builder
+public record ChatRoomInfoResponse(
+    Long chatRoomId,
+    String receiverNickname,
+    String receiverProfileImage,
+    Long productId,
+    String accommodationName,
+    String roomName,
+    ProductStatus productStatus,
+    Integer price
+) {
+
+}

--- a/src/main/java/site/goldenticket/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/site/goldenticket/domain/chat/repository/ChatRepository.java
@@ -1,8 +1,10 @@
 package site.goldenticket.domain.chat.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.goldenticket.domain.chat.entity.Chat;
 
 public interface ChatRepository extends JpaRepository<Chat, Long> {
 
+    List<Chat> findAllByChatRoomId(Long chatRoomId);
 }

--- a/src/main/java/site/goldenticket/domain/chat/service/ChatService.java
+++ b/src/main/java/site/goldenticket/domain/chat/service/ChatService.java
@@ -1,12 +1,77 @@
 package site.goldenticket.domain.chat.service;
 
+import static site.goldenticket.common.response.ErrorCode.CHAT_ROOM_NOT_FOUND;
+
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import site.goldenticket.common.exception.CustomException;
+import site.goldenticket.domain.chat.dto.ChatResponse;
+import site.goldenticket.domain.chat.dto.ChatRoomDetailResponse;
+import site.goldenticket.domain.chat.dto.ChatRoomInfoResponse;
+import site.goldenticket.domain.chat.entity.Chat;
+import site.goldenticket.domain.chat.entity.ChatRoom;
+import site.goldenticket.domain.chat.entity.SenderType;
+import site.goldenticket.domain.chat.repository.ChatRepository;
+import site.goldenticket.domain.chat.repository.ChatRoomRepository;
+import site.goldenticket.domain.product.model.Product;
+import site.goldenticket.domain.product.service.ProductService;
+import site.goldenticket.domain.user.entity.User;
+import site.goldenticket.domain.user.service.UserService;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class ChatService {
 
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRepository chatRepository;
+    private final ProductService productService;
+    private final UserService userService;
+
+    public ChatRoomDetailResponse getChatRoomDetail(Long userId, Long chatRoomId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+            .orElseThrow(()-> new CustomException(CHAT_ROOM_NOT_FOUND));
+        Product product = productService.findProduct(chatRoom.getProductId());
+        Long sellerId = 1L;  //판매자 ID 추후 수정 예정
+        Long buyerId = chatRoom.getUserId();
+        Long receiverId = (sellerId.equals(userId)) ? buyerId: sellerId; //채팅 상대 ID
+        User receiver = userService.findUser(receiverId);
+
+        ChatRoomInfoResponse chatRoomInfoResponse = ChatRoomInfoResponse.builder()
+            .chatRoomId(chatRoomId)
+            .accommodationName(product.getAccommodationName())
+            .roomName(product.getRoomName())
+            .receiverProfileImage(receiver.getImageUrl())
+            .receiverNickname(receiver.getNickname())
+            .price(product.getGoldenPrice()) //네고 승인 시, 네고가격으로 수정하는 로직 추가 예정
+            .productId(product.getId())
+            .productStatus(product.getProductStatus())
+            .build();
+
+        List<Chat> chatList = chatRepository.findAllByChatRoomId(chatRoomId);
+        List<ChatResponse> chatResponseList = new ArrayList<>();
+
+        for (Chat chat : chatList) {
+
+            // 시스템 메세지 필터
+            if(chat.getSenderType().equals(SenderType.SYSTEM)&&chat.getUserId()!=userId)
+                continue;
+
+            ChatResponse chatResponse = ChatResponse.builder()
+                .chatId(chat.getId())
+                .senderType(chat.getSenderType())
+                .userId(chat.getUserId())
+                .content(chat.getContent())
+                .createdAt(chat.getCreatedAt())
+                .build();
+            chatResponseList.add(chatResponse);
+        }
+
+        return ChatRoomDetailResponse.builder()
+            .chatRoomInfoResponse(chatRoomInfoResponse)
+            .chatResponseList(chatResponseList).build();
+    }
 }

--- a/src/main/java/site/goldenticket/domain/product/service/ProductService.java
+++ b/src/main/java/site/goldenticket/domain/product/service/ProductService.java
@@ -1,13 +1,23 @@
 package site.goldenticket.domain.product.service;
 
+import static site.goldenticket.common.response.ErrorCode.PRODUCT_NOT_FOUND;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import site.goldenticket.common.exception.CustomException;
+import site.goldenticket.domain.product.model.Product;
 import site.goldenticket.domain.product.repository.ProductRepository;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class ProductService {
+
     private final ProductRepository productRepository;
+
+    public Product findProduct(Long productId) {
+        return productRepository.findById(productId)
+            .orElseThrow(() -> new CustomException(PRODUCT_NOT_FOUND));
+    }
 }

--- a/src/main/java/site/goldenticket/domain/user/service/UserService.java
+++ b/src/main/java/site/goldenticket/domain/user/service/UserService.java
@@ -13,6 +13,7 @@ import site.goldenticket.domain.user.repository.UserRepository;
 
 import static site.goldenticket.common.response.ErrorCode.ALREADY_EXIST_EMAIL;
 import static site.goldenticket.common.response.ErrorCode.ALREADY_EXIST_NICKNAME;
+import static site.goldenticket.common.response.ErrorCode.USER_NOT_FOUND;
 
 @Slf4j
 @Service
@@ -52,5 +53,10 @@ public class UserService {
         if (isExistNickname(joinRequest.nickname())) {
             throw new CustomException(ALREADY_EXIST_NICKNAME);
         }
+    }
+
+    public User findUser(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
     }
 }


### PR DESCRIPTION
개발 내용
-
- 채팅방 상세 조회 API 구현

추가 사항
-
- [ ] 시큐리티 적용
- [ ] 판매자 ID 가져오는 로직 추가
- [ ] 네고승인 시, 네고가 보여주는 로직 추가
- [ ] 채팅내역 정렬 (등록순)

질문 사항
-
- ERD에는 상품 테이블에 판매자 ID가 있는데 Entity상에는 없어서 질문드립니다~! 
- NOT_FOUND 예외인 경우, BAD_REQUEST 인지 NOT_FOUND인지 헷갈립니다..!

전달 사항
-
- 상품이랑 유저정보가 필요해서 id로 entity 조회하는 메서드 각 도메인 서비스에 만들어서 이용했습니다!  