### PR TITLE
feat: 네고 가능 여부 조회 API 응답값 추가(채팅방 ID)

### DIFF
--- a/src/main/java/site/goldenticket/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/site/goldenticket/domain/chat/repository/ChatRoomRepository.java
@@ -1,11 +1,17 @@
 package site.goldenticket.domain.chat.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.goldenticket.domain.chat.entity.ChatRoom;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     List<ChatRoom> findAllByUserId(Long userId);
+
     List<ChatRoom> findAllByProductId(Long productId);
+
+    Optional<ChatRoom> findByUserIdAndProductId(Long userId, Long productId);
+
+    Boolean existsByUserIdAndProductId(Long userId, Long productId);
 }

--- a/src/main/java/site/goldenticket/domain/chat/service/ChatService.java
+++ b/src/main/java/site/goldenticket/domain/chat/service/ChatService.java
@@ -194,4 +194,13 @@ public class ChatService {
 
         return chatList;
     }
+
+    public ChatRoom getChatRoomByBuyerIdAndProductId(Long buyerId, Long productId) {
+        return chatRoomRepository.findByUserIdAndProductId(buyerId, productId)
+            .orElseThrow(() -> new CustomException(CHAT_ROOM_NOT_FOUND));
+    }
+
+    public Boolean existsChatRoomByUserIdAndProductId(Long userId, Long productId) {
+        return chatRoomRepository.existsByUserIdAndProductId(userId, productId);
+    }
 }

--- a/src/main/java/site/goldenticket/domain/nego/dto/response/NegoAvailableResponse.java
+++ b/src/main/java/site/goldenticket/domain/nego/dto/response/NegoAvailableResponse.java
@@ -4,7 +4,8 @@ import lombok.Builder;
 
 @Builder
 public record NegoAvailableResponse(
-    Boolean negoAvailable
+    Boolean negoAvailable,
+    Long chatRoomId
 ) {
 
 }

--- a/src/main/java/site/goldenticket/domain/nego/service/NegoServiceImpl.java
+++ b/src/main/java/site/goldenticket/domain/nego/service/NegoServiceImpl.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import site.goldenticket.common.exception.CustomException;
 import site.goldenticket.common.response.ErrorCode;
+import site.goldenticket.domain.chat.entity.ChatRoom;
 import site.goldenticket.domain.chat.service.ChatService;
 import site.goldenticket.domain.nego.dto.request.PriceProposeRequest;
 import site.goldenticket.domain.nego.dto.response.HandoverResponse;
@@ -223,11 +224,13 @@ public class NegoServiceImpl implements NegoService {
      * 네고 가능 여부 조회
      * @param userId 회원 ID
      * @param productId 상품 ID
-     * @return 네고 가능 여부 응답 DTO
+     * @return 네고 가능 여부 응답 DTO (네고 가능 여부, 네고 가능 시, 채팅방 ID)
      */
     public NegoAvailableResponse isAvailableNego(Long userId, Long productId) {
         Boolean negoAvailable = true;
+        Long chatRoomId = -1L;
         Product product = productService.getProduct(productId);
+        //본인이 판매하는 상품이면 네고 불가
         if (product.getUserId().equals(userId)) {
             negoAvailable = false;
         }
@@ -238,8 +241,12 @@ public class NegoServiceImpl implements NegoService {
         } else {
             if (!negoRepository.existsByUser_IdAndProduct_Id(userId, productId)) {
                 //네고 이력 없는 경우 : 채팅방 생성 + 네고 가능
-                chatService.createChatRoom(userId, productId);
-                negoAvailable = true;
+                if (!chatService.existsChatRoomByUserIdAndProductId(userId, productId)) {
+                    ChatRoom chatRoom = chatService.createChatRoom(userId, productId);
+                    negoAvailable = true;
+                    chatRoomId = chatRoom.getId();
+                    System.out.println(chatRoomId);
+                }
             } else {
                 //네고 이력 있는 경우 : 2차 네고(거절 혹은 승인) OR 재결제 -> 네고 불가
                 List<Nego> negoList = negoRepository.findAllByUser_IdAndProduct_Id(userId,
@@ -253,8 +260,12 @@ public class NegoServiceImpl implements NegoService {
                 }
             }
         }
+        if (negoAvailable) {
+            chatRoomId = chatService.getChatRoomByBuyerIdAndProductId(userId, productId).getId();
+        }
         return NegoAvailableResponse.builder()
             .negoAvailable(negoAvailable)
+            .chatRoomId(chatRoomId)
             .build();
     }
 }


### PR DESCRIPTION
- 네고 가능 여부 조회 시, 채팅방 ID도 응답정보에 추가
- 네고 가능하면 해당 채팅방 ID
- 네고 불가하면 -1 반환

- 네고 이력 없을 때 바로 채팅방 생성하지 않고 채팅방이 존재하는지 확인한 후에 채팅방 생성하도록 수정