### PR TITLE
Feature/60 야놀자 로그인 응답 값 수정

### DIFF
--- a/src/main/java/site/goldenticket/domain/security/controller/SecurityController.java
+++ b/src/main/java/site/goldenticket/domain/security/controller/SecurityController.java
@@ -5,12 +5,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import site.goldenticket.common.exception.CustomException;
 import site.goldenticket.common.response.CommonResponse;
 import site.goldenticket.common.security.authentication.dto.AuthenticationToken;
 import site.goldenticket.common.security.authentication.dto.LoginRequest;
 import site.goldenticket.domain.security.dto.ReissueRequest;
-import site.goldenticket.domain.security.dto.YanoljaUserResponse;
+import site.goldenticket.domain.security.dto.YanoljaLoginResponse;
 import site.goldenticket.domain.security.service.SecurityService;
 
 @RestController
@@ -26,12 +25,8 @@ public class SecurityController {
     }
 
     @PostMapping("/yanolja-login")
-    public ResponseEntity<CommonResponse<?>> yanoljaLogin(@RequestBody LoginRequest loginRequest) {
-        YanoljaUserResponse yanoljaUserResponse = securityService.fetchYanoljaUser(loginRequest);
-        try {
-            return ResponseEntity.ok(CommonResponse.ok(securityService.generateToken(yanoljaUserResponse.id())));
-        } catch (CustomException e) {
-            return ResponseEntity.ok(CommonResponse.fail(yanoljaUserResponse));
-        }
+    public ResponseEntity<CommonResponse<YanoljaLoginResponse>> yanoljaLogin(@RequestBody LoginRequest loginRequest) {
+        YanoljaLoginResponse response = securityService.yanoljaLogin(loginRequest);
+        return ResponseEntity.ok(CommonResponse.ok(response));
     }
 }

--- a/src/main/java/site/goldenticket/domain/security/dto/YanoljaLoginResponse.java
+++ b/src/main/java/site/goldenticket/domain/security/dto/YanoljaLoginResponse.java
@@ -1,0 +1,12 @@
+package site.goldenticket.domain.security.dto;
+
+import lombok.Builder;
+import site.goldenticket.common.security.authentication.dto.AuthenticationToken;
+
+@Builder
+public record YanoljaLoginResponse(
+        boolean isFirst,
+        AuthenticationToken token,
+        YanoljaUserResponse userInfo
+) {
+}


### PR DESCRIPTION
기존 야놀자 로그인 시, 
1. 토큰 정보
2. 야놀자 회원 정보
둘 중 최초 로그인 여부에 따라 각각의 형태의 응답에서

- 최초 로그인 여부
- 야놀자 회원 정보
- 토큰 정보
모두 응답하는 형태로 변경
최초 로그인인 경우, 토큰 정보는 null로 응답한다.