### PR TITLE
Hotfix/161 야놀자 로그인 응답 수정

### DIFF
--- a/src/main/java/site/goldenticket/domain/security/dto/YanoljaLoginResponse.java
+++ b/src/main/java/site/goldenticket/domain/security/dto/YanoljaLoginResponse.java
@@ -10,21 +10,4 @@ public record YanoljaLoginResponse(
         YanoljaUserResponse userInfo
 ) {
 
-    public static YanoljaLoginResponse firstLoginUser(YanoljaUserResponse yanoljaUser) {
-        return YanoljaLoginResponse.builder()
-                .isFirst(true)
-                .userInfo(yanoljaUser)
-                .build();
-    }
-
-    public static YanoljaLoginResponse loginUser(
-            YanoljaUserResponse yanoljaUser,
-            AuthenticationToken token
-    ) {
-        return YanoljaLoginResponse.builder()
-                .isFirst(true)
-                .userInfo(yanoljaUser)
-                .token(token)
-                .build();
-    }
 }

--- a/src/main/java/site/goldenticket/domain/security/service/SecurityService.java
+++ b/src/main/java/site/goldenticket/domain/security/service/SecurityService.java
@@ -21,7 +21,6 @@ import site.goldenticket.domain.user.repository.UserRepository;
 import java.util.UUID;
 
 import static site.goldenticket.common.response.ErrorCode.LOGIN_FAIL;
-import static site.goldenticket.common.response.ErrorCode.USER_NOT_FOUND;
 
 @Slf4j
 @Service
@@ -61,18 +60,13 @@ public class SecurityService implements UserDetailsService {
     }
 
     private YanoljaLoginResponse createYanoljaLoginResponse(YanoljaUserResponse yanoljaUser) {
-        try {
-            User user = findByYanoljaId(yanoljaUser.id());
-            AuthenticationToken token = generateToken(user.getEmail());
-            return YanoljaLoginResponse.loginUser(yanoljaUser, token);
-        } catch (CustomException e) {
-            return YanoljaLoginResponse.firstLoginUser(yanoljaUser);
-        }
-    }
-
-    private User findByYanoljaId(Long yanoljaId) {
-        return userRepository.findByYanoljaId(yanoljaId)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        boolean isFirst = userRepository.existsByYanoljaId(yanoljaUser.id());
+        AuthenticationToken token = generateToken(yanoljaUser.email());
+        return YanoljaLoginResponse.builder()
+                .isFirst(isFirst)
+                .userInfo(yanoljaUser)
+                .token(token)
+                .build();
     }
 
     private AuthenticationToken generateToken(String email) {


### PR DESCRIPTION
closed #161 

야놀자 로그인 응답값 수정
- 최초 로그인 상관없이 Token과 야놀자 계정 정보 반환
- 최초 로그인 여부는 `isFirst` 필드를 통해 구분