### PR TITLE
Hotfix/164 관심 지역 수정 구현

### DIFF
--- a/src/main/java/site/goldenticket/domain/user/entity/User.java
+++ b/src/main/java/site/goldenticket/domain/user/entity/User.java
@@ -12,6 +12,7 @@ import site.goldenticket.common.exception.CustomException;
 import site.goldenticket.domain.user.wish.entity.WishRegion;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -111,8 +112,13 @@ public class User extends BaseTimeEntity {
         this.accountNumber = null;
     }
 
-    public void registerWishRegion(WishRegion wishRegion) {
-        wishRegions.add(wishRegion);
+    public void registerWishRegions(List<WishRegion> wishRegions) {
+        this.wishRegions.removeIf(wishRegion -> !wishRegions.contains(wishRegion));
+        wishRegions.forEach(this::addWishRegion);
+    }
+
+    private void addWishRegion(WishRegion wishRegion) {
+        this.wishRegions.add(wishRegion);
         wishRegion.registerUser(this);
     }
 

--- a/src/main/java/site/goldenticket/domain/user/wish/service/WishRegionService.java
+++ b/src/main/java/site/goldenticket/domain/user/wish/service/WishRegionService.java
@@ -33,7 +33,7 @@ public class WishRegionService {
         log.info("User ID [{}] Register Regions = {}", userId, wishRegionRegisterRequest.regions());
 
         List<WishRegion> wishRegions = wishRegionRegisterRequest.toEntity();
-        wishRegions.forEach(user::registerWishRegion);
+        user.registerWishRegions(wishRegions);
 
         if (user.isValidRegionSize(MAXIMUM_REGION_SIZE)) {
             throw new CustomException(ALREADY_REGISTER_YANOLJA_ID);


### PR DESCRIPTION
closed #164 

- 관심 지역 등록 시, 삽입과 삭제가 동시에 일어나도록 수정
- 동일한 지역에 대해 변경감지 일어나지 안도록 관리