### PR TITLE
feat: 채팅 테스트 api 접근 허용 경로 수정 및 네고 응답값 변경

### DIFF
--- a/src/main/java/site/goldenticket/common/security/SecurityConfiguration.java
+++ b/src/main/java/site/goldenticket/common/security/SecurityConfiguration.java
@@ -43,7 +43,8 @@ public class SecurityConfiguration {
             "/h2-console/**",
             "/dummy/**",
             "/payments/**",
-            "/home"
+            "/home",
+            "/chats/test/**"
     };
 
     private static final String[] PERMIT_ALL_GET_URLS = new String[]{
@@ -61,8 +62,7 @@ public class SecurityConfiguration {
             "/users",
             "/reissue",
             "/yanolja-login",
-            "/alerts/test",
-            "/chats/test/**"
+            "/alerts/test"
     };
 
     private final ObjectMapper objectMapper;

--- a/src/main/java/site/goldenticket/domain/nego/controller/NegoController.java
+++ b/src/main/java/site/goldenticket/domain/nego/controller/NegoController.java
@@ -8,7 +8,7 @@ import site.goldenticket.common.response.CommonResponse;
 import site.goldenticket.domain.nego.dto.request.PriceProposeRequest;
 import site.goldenticket.domain.nego.dto.response.HandoverResponse;
 import site.goldenticket.domain.nego.dto.response.NegoAvailableResponse;
-import site.goldenticket.domain.nego.dto.response.NegoListResponse;
+import site.goldenticket.domain.nego.dto.response.NegoTestListResponse;
 import site.goldenticket.domain.nego.dto.response.NegoResponse;
 import site.goldenticket.domain.nego.dto.response.PayResponse;
 import site.goldenticket.domain.nego.dto.response.PriceProposeResponse;
@@ -68,7 +68,7 @@ public class NegoController {
     }
 
     @GetMapping("/test")
-    public ResponseEntity<CommonResponse<NegoListResponse>> getNegoListForTest() {
+    public ResponseEntity<CommonResponse<NegoTestListResponse>> getNegoListForTest() {
         return ResponseEntity.ok(
             CommonResponse.ok("(테스트용) 모든 네고 기록이 조회되었습니다.", negoService.getNegoListForTest()));
     }

--- a/src/main/java/site/goldenticket/domain/nego/dto/response/NegoTestListResponse.java
+++ b/src/main/java/site/goldenticket/domain/nego/dto/response/NegoTestListResponse.java
@@ -4,8 +4,8 @@ import java.util.List;
 import lombok.Builder;
 
 @Builder
-public record NegoListResponse(
-    List<NegoResponse> negoResponseList
+public record NegoTestListResponse(
+    List<NegoTestResponse> negoTestResponseList
 ) {
 
 }

--- a/src/main/java/site/goldenticket/domain/nego/dto/response/NegoTestResponse.java
+++ b/src/main/java/site/goldenticket/domain/nego/dto/response/NegoTestResponse.java
@@ -1,0 +1,26 @@
+package site.goldenticket.domain.nego.dto.response;
+
+import java.time.LocalDateTime;
+import site.goldenticket.domain.nego.entity.Nego;
+import site.goldenticket.domain.nego.status.NegotiationStatus;
+
+public record NegoTestResponse(
+    Long negoId,
+    Long productId,
+    Long userId,
+    Integer price,
+    Integer count,
+    Boolean consent,
+    NegotiationStatus negotiationStatus,
+    LocalDateTime expirationTime,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {
+
+    public static NegoTestResponse fromEntity(Nego nego) {
+        return new NegoTestResponse(nego.getId(), nego.getProductId(), nego.getUser().getId(),
+            nego.getPrice(), nego.getCount(), nego.getConsent(), nego.getStatus(),
+            nego.getExpirationTime(), nego.getCreatedAt(), nego.getUpdatedAt());
+    }
+
+}

--- a/src/main/java/site/goldenticket/domain/nego/service/NegoService.java
+++ b/src/main/java/site/goldenticket/domain/nego/service/NegoService.java
@@ -32,6 +32,6 @@ public interface NegoService {
 
     NegoAvailableResponse isAvailableNego(Long userId, Long productId); //네고 가능 여부 조회
 
-    NegoListResponse getNegoListForTest(); // 테스트용 모든 네고 기록 조회
+    NegoTestListResponse getNegoListForTest(); // 테스트용 모든 네고 기록 조회
     List<Nego> findByStatusInAndProduct(List<NegotiationStatus> negotiationStatusList, Product product);
 }

--- a/src/main/java/site/goldenticket/domain/nego/service/NegoServiceImpl.java
+++ b/src/main/java/site/goldenticket/domain/nego/service/NegoServiceImpl.java
@@ -443,14 +443,14 @@ public class NegoServiceImpl implements NegoService {
      * 테스트용 네고 기록 조회  (프론트 DB 확인용)
      * @return 네고 Entity List 응답 DTO
      */
-    public NegoListResponse getNegoListForTest() {
+    public NegoTestListResponse getNegoListForTest() {
         List<Nego> negoList = negoRepository.findAll();
-        List<NegoResponse> negoResponseList = new ArrayList<>();
+        List<NegoTestResponse> negoTestResponseList = new ArrayList<>();
         for(Nego nego: negoList) {
-            negoResponseList.add(NegoResponse.fromEntity(nego));
+            negoTestResponseList.add(NegoTestResponse.fromEntity(nego));
         }
-        return NegoListResponse.builder()
-            .negoResponseList(negoResponseList).build();
+        return NegoTestListResponse.builder()
+            .negoTestResponseList(negoTestResponseList).build();
     }
 
     public List<Nego> findByStatusInAndProduct(List<NegotiationStatus> negotiationStatusList,


### PR DESCRIPTION
- 채팅 테스트 api post만 허용 -> 전부 허용
- 네고 db 조회 api에서 보여줄 네고 응답 dto 추가 (NegoTestResponse)