### PR TITLE
Feature/45 회원탈퇴 구현

### DIFF
--- a/src/main/java/site/goldenticket/common/response/ErrorCode.java
+++ b/src/main/java/site/goldenticket/common/response/ErrorCode.java
@@ -63,6 +63,7 @@ public enum ErrorCode {
     ALREADY_REGISTER_YANOLJA_ID(BAD_REQUEST, "이미 등록된 야놀자 아이디가 존재합니다."),
     ALREADY_REGISTER_ACCOUNT(BAD_REQUEST, "이미 등록된 계좌가 존재합니다."),
     INVALID_PASSWORD(BAD_REQUEST, "비밀번호를 확인해 주세요."),
+    ALREADY_DELETE_USER(BAD_REQUEST, "이미 삭제된 사용자입니다."),
 
     // Wish
     WISH_PRODUCT_NOT_FOUND(BAD_REQUEST, "존재하지 않는 관심 상품입니다."),

--- a/src/main/java/site/goldenticket/domain/user/controller/UserController.java
+++ b/src/main/java/site/goldenticket/domain/user/controller/UserController.java
@@ -47,6 +47,16 @@ public class UserController {
         return ResponseEntity.ok(CommonResponse.ok(UserResponse.from(user)));
     }
 
+    @DeleteMapping
+    public ResponseEntity<CommonResponse<Void>> removeUser(
+            @RequestBody @Validated RemoveUserRequest removeUserRequest,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        Long userId = principalDetails.getUserId();
+        userService.deleteUser(userId, removeUserRequest);
+        return ResponseEntity.ok(CommonResponse.ok());
+    }
+
     @PutMapping("/me")
     public ResponseEntity<CommonResponse<Void>> changeProfile(
             @RequestBody @Validated ChangeProfileRequest changeProfileRequest,

--- a/src/main/java/site/goldenticket/domain/user/dto/RemoveUserRequest.java
+++ b/src/main/java/site/goldenticket/domain/user/dto/RemoveUserRequest.java
@@ -1,0 +1,14 @@
+package site.goldenticket.domain.user.dto;
+
+import site.goldenticket.domain.user.entity.DeleteReason;
+
+public record RemoveUserRequest(
+        String reason
+) {
+
+    public DeleteReason toEntity() {
+        return DeleteReason.builder()
+                .reason(reason)
+                .build();
+    }
+}

--- a/src/main/java/site/goldenticket/domain/user/entity/Agreement.java
+++ b/src/main/java/site/goldenticket/domain/user/entity/Agreement.java
@@ -16,7 +16,7 @@ public class Agreement extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
@@ -29,6 +29,6 @@ public class Agreement extends BaseTimeEntity {
 
     public void registerUser(User user) {
         this.user = user;
-        user.registerAlertSetting(this);
+        user.registerAgreement(this);
     }
 }

--- a/src/main/java/site/goldenticket/domain/user/entity/DeleteReason.java
+++ b/src/main/java/site/goldenticket/domain/user/entity/DeleteReason.java
@@ -7,23 +7,30 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.goldenticket.common.entiy.BaseTimeEntity;
 
+import static jakarta.persistence.FetchType.LAZY;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "deleted")
-public class Delete extends BaseTimeEntity {
+public class DeleteReason extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long userId;
     private String reason;
 
-    @Builder
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "userId")
+    private User user;
 
-    public Delete(Long userId, String reason) {
-        this.userId = userId;
+    @Builder
+    private DeleteReason(String reason) {
         this.reason = reason;
+    }
+
+    public void registerUser(User user) {
+        this.user = user;
     }
 }

--- a/src/main/java/site/goldenticket/domain/user/entity/User.java
+++ b/src/main/java/site/goldenticket/domain/user/entity/User.java
@@ -11,10 +11,7 @@ import site.goldenticket.common.entiy.BaseTimeEntity;
 import site.goldenticket.common.exception.CustomException;
 import site.goldenticket.domain.user.wish.entity.WishRegion;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.EnumType.STRING;
@@ -30,7 +27,7 @@ import static site.goldenticket.domain.user.entity.RoleType.ROLE_USER;
 @NoArgsConstructor(access = PROTECTED)
 @Table(name = "users")
 @SQLRestriction("deleted = false")
-@ToString(exclude = {"password", "agreement", "wishRegions"})
+@ToString(exclude = {"password", "agreement", "wishRegions", "deleteReasons"})
 public class User extends BaseTimeEntity {
 
     @Id
@@ -50,7 +47,6 @@ public class User extends BaseTimeEntity {
     private RoleType role;
 
     private Long yanoljaId;
-    private boolean deleted;
 
     @OneToOne(
             mappedBy = "user", fetch = LAZY,
@@ -63,6 +59,14 @@ public class User extends BaseTimeEntity {
             cascade = ALL, orphanRemoval = true
     )
     private final Set<WishRegion> wishRegions = new HashSet<>();
+
+    private boolean deleted;
+
+    @OneToMany(
+            mappedBy = "user", fetch = LAZY,
+            cascade = ALL, orphanRemoval = true
+    )
+    private final List<DeleteReason> deleteReasons = new ArrayList<>();
 
     @Builder
     private User(

--- a/src/main/java/site/goldenticket/domain/user/entity/User.java
+++ b/src/main/java/site/goldenticket/domain/user/entity/User.java
@@ -125,16 +125,12 @@ public class User extends BaseTimeEntity {
         wishRegions.forEach(this::addWishRegion);
     }
 
-    private void addWishRegion(WishRegion wishRegion) {
-        this.wishRegions.add(wishRegion);
-        wishRegion.registerUser(this);
-    }
-
     public boolean isValidRegionSize(int maxSize) {
         return wishRegions.size() > maxSize;
     }
 
-    public void setPassword(String password) {
-        this.password = password;
+    private void addWishRegion(WishRegion wishRegion) {
+        this.wishRegions.add(wishRegion);
+        wishRegion.registerUser(this);
     }
 }

--- a/src/main/java/site/goldenticket/domain/user/entity/User.java
+++ b/src/main/java/site/goldenticket/domain/user/entity/User.java
@@ -129,6 +129,12 @@ public class User extends BaseTimeEntity {
         return wishRegions.size() > maxSize;
     }
 
+    public void deleted(DeleteReason deleteReason) {
+        this.deleted = true;
+        deleteReasons.add(deleteReason);
+        deleteReason.registerUser(this);
+    }
+
     private void addWishRegion(WishRegion wishRegion) {
         this.wishRegions.add(wishRegion);
         wishRegion.registerUser(this);

--- a/src/main/java/site/goldenticket/domain/user/entity/User.java
+++ b/src/main/java/site/goldenticket/domain/user/entity/User.java
@@ -26,7 +26,7 @@ import static site.goldenticket.domain.user.entity.RoleType.ROLE_USER;
 @NoArgsConstructor(access = PROTECTED)
 @Table(name = "users")
 @SQLRestriction("deleted = false")
-@ToString(exclude = {"password", "agreement", "wishRegions", "deleteReasons"})
+@ToString(exclude = {"password", "agreements", "wishRegions", "deleteReasons"})
 public class User extends BaseTimeEntity {
 
     @Id
@@ -47,11 +47,11 @@ public class User extends BaseTimeEntity {
 
     private Long yanoljaId;
 
-    @OneToOne(
+    @OneToMany(
             mappedBy = "user", fetch = LAZY,
             cascade = ALL, orphanRemoval = true
     )
-    private Agreement agreement;
+    private final List<Agreement> agreements = new ArrayList<>();
 
     @OneToMany(
             mappedBy = "user", fetch = LAZY,
@@ -85,8 +85,8 @@ public class User extends BaseTimeEntity {
         this.yanoljaId = yanoljaId;
     }
 
-    public void registerAlertSetting(Agreement agreement) {
-        this.agreement = agreement;
+    public void registerAgreement(Agreement agreement) {
+        this.agreements.add(agreement);
     }
 
     public void updateProfile(String nickname) {

--- a/src/main/java/site/goldenticket/domain/user/entity/User.java
+++ b/src/main/java/site/goldenticket/domain/user/entity/User.java
@@ -18,8 +18,7 @@ import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
-import static site.goldenticket.common.response.ErrorCode.ALREADY_REGISTER_ACCOUNT;
-import static site.goldenticket.common.response.ErrorCode.ALREADY_REGISTER_YANOLJA_ID;
+import static site.goldenticket.common.response.ErrorCode.*;
 import static site.goldenticket.domain.user.entity.RoleType.ROLE_USER;
 
 @Getter
@@ -130,6 +129,10 @@ public class User extends BaseTimeEntity {
     }
 
     public void deleted(DeleteReason deleteReason) {
+        if (this.deleted) {
+            throw new CustomException(ALREADY_DELETE_USER);
+        }
+
         this.deleted = true;
         deleteReasons.add(deleteReason);
         deleteReason.registerUser(this);

--- a/src/main/java/site/goldenticket/domain/user/service/UserService.java
+++ b/src/main/java/site/goldenticket/domain/user/service/UserService.java
@@ -10,6 +10,7 @@ import site.goldenticket.common.exception.CustomException;
 import site.goldenticket.common.security.authentication.dto.LoginRequest;
 import site.goldenticket.domain.security.dto.YanoljaUserResponse;
 import site.goldenticket.domain.user.dto.*;
+import site.goldenticket.domain.user.entity.DeleteReason;
 import site.goldenticket.domain.user.entity.User;
 import site.goldenticket.domain.user.repository.UserRepository;
 
@@ -131,7 +132,7 @@ public class UserService {
         User user = userRepository.findByEmail(resetPasswordRequest.getEmail())
                 .orElseThrow(() -> new CustomException("존재하지 않는 유저입니다.",USER_NOT_FOUND));
 
-        user.setPassword(hashedPassword);
+        user.updatePassword(hashedPassword);
 
         emailService.sendPasswordResetEmail(resetPasswordRequest.getEmail(), newPassword);
     }

--- a/src/main/java/site/goldenticket/domain/user/service/UserService.java
+++ b/src/main/java/site/goldenticket/domain/user/service/UserService.java
@@ -55,6 +55,15 @@ public class UserService {
     }
 
     @Transactional
+    public void deleteUser(Long userId, RemoveUserRequest removeUserRequest) {
+        User user = findById(userId);
+        log.info("User [{}] Delete Reason = {}", user.getEmail(), removeUserRequest);
+
+        DeleteReason deleteReason = removeUserRequest.toEntity();
+        user.deleted(deleteReason);
+    }
+
+    @Transactional
     public void updateProfile(Long userId, ChangeProfileRequest changeProfileRequest) {
         log.info("User ID [{}] Change Profile = {}", userId, changeProfileRequest);
         updateProfileValidate(changeProfileRequest);

--- a/src/test/java/site/goldenticket/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/site/goldenticket/domain/user/controller/UserControllerTest.java
@@ -90,6 +90,30 @@ class UserControllerTest extends ApiTest {
     }
 
     @Test
+    @DisplayName("사용자 삭제 검증")
+    void removeUser() {
+        // given
+        RemoveUserRequest request = new RemoveUserRequest("delete reason");
+
+        String url = "/users";
+
+        // when
+        ExtractableResponse<Response> result = RestAssured
+                .given().log().all()
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(APPLICATION_JSON_VALUE)
+                .body(request)
+                .when()
+                .delete(url)
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(result.statusCode()).isEqualTo(OK.value());
+        assertThat(userRepository.findById(user.getId()).isPresent()).isFalse();
+    }
+
+    @Test
     @DisplayName("사용자 프로필 수정 검증")
     void changeProfile() {
         // given


### PR DESCRIPTION
closed #45 

- 사용자 삭제 로직 구현(Soft Delete)
- 동의 내역 연관관계 변경
- 실제 OneToOne 관계이지만 Lazy 로딩을 위해 OneToMany로 연관관계 설정