### PR TITLE
Hotfix/93 야놀자 아이디 중복 연동 예외 처리

### DIFF
--- a/src/main/java/site/goldenticket/domain/user/service/UserService.java
+++ b/src/main/java/site/goldenticket/domain/user/service/UserService.java
@@ -14,6 +14,8 @@ import site.goldenticket.domain.user.entity.DeleteReason;
 import site.goldenticket.domain.user.entity.User;
 import site.goldenticket.domain.user.repository.UserRepository;
 
+import java.util.Objects;
+
 import static site.goldenticket.common.response.ErrorCode.*;
 
 @Slf4j
@@ -96,6 +98,7 @@ public class UserService {
     @Transactional
     public Long yanoljaLogin(LoginRequest loginRequest, Long userId) {
         YanoljaUserResponse yanoljaUser = getYanoljaUser(loginRequest);
+        yanoljaLoginValidate(userId, yanoljaUser);
         User user = findById(userId);
         user.registerYanoljaId(yanoljaUser.id());
         return yanoljaUser.id();
@@ -131,6 +134,14 @@ public class UserService {
                 loginRequest,
                 YanoljaUserResponse.class
         ).orElseThrow(() -> new CustomException(LOGIN_FAIL));
+    }
+
+    private void yanoljaLoginValidate(Long userId, YanoljaUserResponse yanoljaUser) {
+        userRepository.findByYanoljaId(yanoljaUser.id()).ifPresent(user -> {
+            if (!Objects.equals(userId, user.getId())) {
+                throw new CustomException(ALREADY_REGISTER_YANOLJA_ID);
+            }
+        });
     }
 
     @Transactional

--- a/src/main/java/site/goldenticket/domain/user/service/UserService.java
+++ b/src/main/java/site/goldenticket/domain/user/service/UserService.java
@@ -15,6 +15,7 @@ import site.goldenticket.domain.user.entity.User;
 import site.goldenticket.domain.user.repository.UserRepository;
 
 import java.util.Objects;
+import java.util.UUID;
 
 import static site.goldenticket.common.response.ErrorCode.*;
 
@@ -44,7 +45,7 @@ public class UserService {
         joinValidate(joinRequest);
         log.info("Join User Info = {}", joinRequest);
 
-        String encodePassword = passwordEncoder.encode(joinRequest.password());
+        String encodePassword = getJoinPassword(joinRequest);
         User user = joinRequest.toEntity(encodePassword);
         userRepository.save(user);
         return user.getId();
@@ -110,6 +111,13 @@ public class UserService {
         }
 
         duplicateNickname(joinRequest.nickname());
+    }
+
+    private String getJoinPassword(JoinRequest joinRequest) {
+        if (Objects.isNull(joinRequest.yanoljaId())) {
+            return passwordEncoder.encode(joinRequest.password());
+        }
+        return passwordEncoder.encode(UUID.randomUUID().toString());
     }
 
     private void updateProfileValidate(ChangeProfileRequest changeProfileRequest) {


### PR DESCRIPTION
closed #93 

- 상품 등록을 위한 야놀자 로그인 시, 여러 아이디에 야놀자 아이디가 연동될 수 있다.
- 야놀자 아이디 연동 시, 이미 연동된 아이디면 예외를 발생시킨다.
- 야놀라 로그인을 통한 회원가입이면, 랜덤 비밀번호를 등록한다.