### PR TITLE
Feature/12 결제 부분 수정

### DIFF
--- a/src/main/java/site/goldenticket/domain/nego/entity/Nego.java
+++ b/src/main/java/site/goldenticket/domain/nego/entity/Nego.java
@@ -120,7 +120,7 @@ public class Nego {
         this.updatedAt = updatedAt;
     }
 
-    public void completed() {
-        status = NegotiationStatus.NEGOTIATION_COMPLETED;
+    public void transferPending() {
+        status = NegotiationStatus.TRANSFER_PENDING;
     }
 }

--- a/src/main/java/site/goldenticket/domain/product/model/Product.java
+++ b/src/main/java/site/goldenticket/domain/product/model/Product.java
@@ -120,13 +120,10 @@ public class Product {
         this.productStatus = productStatus;
     }
 
-    public boolean isOnSale() {
-        return this.productStatus == ProductStatus.SELLING;
+    public boolean isNotOnSale() {
+        return this.productStatus == ProductStatus.EXPIRED || this.productStatus == ProductStatus.SOLD_OUT;
     }
 
-    public boolean isNotOnSale() {
-        return !isOnSale();
-    }
 
     public void setGoldenPrice(int goldenPrice) {
         this.goldenPrice = goldenPrice;


### PR DESCRIPTION
- 결제 상세 페이지 들어갈때 상품 상태 예약중인 경우
  - 자기가 네고 한 사람이고 결제 대기중이라면 상세페이지 들어감
  - 이외의 경우이면 상세페이지 못들어가도록
- 결제 버튼 눌럿을때(사전 검증시)
  -  상품상태 = 예약중, 해당 경우에 본인이 네고를 진행하였고 결제 대기중인지 확인
- 결제 결과 날라올때(사후 검증시)
  - 상품 상태: 상품 만료, 솔드아웃 
    - 결제 결과 실패
  - 상품 상태: 예약중
    - 네고를 하지 않은 사람이라면? 
      - 결제 결과 실패
    - 네고를 한 사람이라면?
      - 처음 네고 상태: 결제 대기중(상품 상태: 예약중) -> 결제 완료시 상태: 타임아웃(상품 상태: 판매중)
        - 결제 결과 실패
      - 처음 네고 상태: 네고중, 타임아웃, 네고 취소 -> 결제 완료시 상태: 같음
        - 결제 결과 실패
      -  처음 네고 상태: 결제 대기중 -> 결제 완료시 상태: 결제 대기중
        - 결제 결과 성공
        - 네고 상태 양도 대기중
  - 상품 상태: 판매중
    - 네고를 하지 않은 사람? 
      -  결제 결과 성공
    - 네고 한 사람?
      - 처음 네고 상태: 결제 대기중(상품 상태: 예약중) -> 결제 완료시 상태: 타임아웃(상품 상태: 판매중)
        - 결제 결과 타임아웃
      - 처음 네고 상태: 네고중, 타임아웃, 네고 취소 -> 결제 완료시 상태: 같음
        - 결제 결과 성공
        - 네고 상태 양도 대기중
      -  처음 네고 상태: 결제 대기중 -> 결제 완료시 상태: 결제 대기중
        - 결제 결과 성공
        - 네고 상태 양도 대기중